### PR TITLE
feat: create crawler for all playlists

### DIFF
--- a/src/crawlerAllPlaylists.js
+++ b/src/crawlerAllPlaylists.js
@@ -1,0 +1,59 @@
+const puppeteer = require('puppeteer-core');
+const os = require('os');
+const getVideosTime = require('./getVideosTime');
+const getPlaylists = require('./getPlaylists');
+
+function getFormattedTime([hours, minutes, seconds]) {
+  const minutesFromSeconds = Math.floor(seconds / 60);
+
+  seconds = seconds % 60;
+  minutes += minutesFromSeconds;
+
+  const hoursFromMinutes = Math.floor(minutes / 60);
+
+  minutes = minutes % 60;
+  hours += hoursFromMinutes;  
+
+  return `${hours}:${minutes}:${seconds}`; 
+}
+
+const executablePaths = {
+  'linux': '/usr/bin/google-chrome',
+  'darwin': '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+};
+
+const platform = os.platform();
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: true,
+    executablePath: executablePaths[platform]
+  });
+
+  const page = await browser.newPage();
+
+  const playlists = await getPlaylists(page, 'https://www.youtube.com/c/RocketSeat/playlists');
+  const playlistsTimes = [];
+
+  for (const playlist of playlists) {
+    const time = await getVideosTime(page, playlist.url);
+    
+
+    playlistsTimes.push({
+      time,
+      ...playlist
+    });
+
+    console.log(playlist.title + ": " + getFormattedTime(time));
+  }
+
+  const times = playlistsTimes.reduce((acc, { time }) => {
+    return [acc[0] + time[0], acc[1] + time[1], acc[2] + time[2]]; 
+  }, [0, 0, 0]);
+
+  console.log(
+    `Produzimos ${getFormattedTime(times)} de conteúdo`
+  );
+  
+  await browser.close();
+})();

--- a/src/getPlaylists.js
+++ b/src/getPlaylists.js
@@ -1,0 +1,18 @@
+module.exports = async function (page, url) {
+  await page.goto(url, {
+    waitUntil: "networkidle2",
+  });
+
+  return await page.evaluate(() => {
+    const elements = document.querySelectorAll(
+      "ytd-grid-playlist-renderer"
+    );
+
+    return [...elements].map(playlistElement => {
+      return {
+        url: playlistElement.querySelector('.yt-formatted-string').href,
+        title: playlistElement.querySelector('h3 a').innerHTML,
+      }
+    });
+  });
+};


### PR DESCRIPTION
Pra galera que quiser saber as horas de todas as playlists, criei o crawler que busca o link de todas e deixei um exemplo de uso

## Saída:
Code/Drops: 23:25:4
Code/Drops Beginners: 13:38:11
#PR: 5:10:51
Podcast FalaDev: 15:57:18
Podcast Alumni: 8:59:14
UI Clone: 23:43:12
Masterclass Beginners: 8:29:20
Master Class: 11:10:59
Podcast Use Case: 1:10:38
Code Challenge: 14:45:22
Behind the Code: 16:21:59
WorkshopDev Especial: 6:52:54
Diário de Bordo: 0:6:55
Fala Dev: 1:11:7
Redux: 1:6:25
React Native: 11:3:7
Git: 1:48:22
ReactJS: 2:53:9
NodeJS: 5:49:9
Docker: 0:43:47
AdonisJS: 0:35:11
CodeQuinta: 10:11:18
Serie API NodeJS: 1:47:9
React Native + Firebase: 0:23:47
Vagrant: 0:10:30

Produzimos 187:34:58 de conteúdo